### PR TITLE
Disable some scorecard checks

### DIFF
--- a/.github/scorecard-policy.yaml
+++ b/.github/scorecard-policy.yaml
@@ -1,0 +1,41 @@
+version: 1
+policies:
+  Token-Permissions:
+      score: 10
+      mode: enforced
+  Dangerous-Workflow:
+      score: 10
+      mode: enforced
+  License:
+      score: 9
+      mode: enforced
+  Pinned-Dependencies:
+      score: 10
+      mode: enforced
+  Security-Policy:
+      score: 10
+      mode: enforced
+  SAST:
+      score: 10
+      mode: enforced
+  Packaging:
+      score: 10
+      mode: enforced
+  Binary-Artifacts:
+      score: 10
+      mode: enforced
+  Signed-Releases:
+      score: 10
+      mode: disabled
+  Dependency-Update-Tool:
+      score: 10
+      mode: enforced
+  Vulnerabilities:
+      score: 10
+      mode: enforced
+  CI-Tests:
+      score: 10
+      mode: enforced
+  Maintained:
+      score: 1
+      mode: enforced

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,9 +4,6 @@
 
 name: Scorecard supply-chain security
 on:
-  # For Branch-Protection check. Only the default branch is supported. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
-  branch_protection_rule:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
@@ -45,6 +42,7 @@ jobs:
         uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
+          policy_file: ./.github/scorecard-policy.yaml
           results_format: sarif
           # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
           # - you want to enable the Branch-Protection check on a *public* repository, or


### PR DESCRIPTION
Checks will always fail for a single-maintainer repository