### PR TITLE
Allow github publish job to connect to upload.pypi.org

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
             github.com:443
             install.python-poetry.org:443
             pypi.org:443
-            test.pypi.org:443
+            *.pypi.org:443
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Before connection to upload.pypi.org were blocked which made the publish job fail.