### PR TITLE
Add new endpoint requirement for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,6 +49,7 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
CodeQL seems to connect release-assets.githubusercontent.com now. Possibly instead of objects.githubusercontent.com, but do not know for sure so leave both in the config.